### PR TITLE
Propagate stream errors

### DIFF
--- a/lib/remove.js
+++ b/lib/remove.js
@@ -9,9 +9,8 @@ const { REMOVE_EVENT } = require('../actions')
 module.exports = async function remove ({ getDb, id, afterClose = () => {} }) {
   const matches = await getEvents({ getDb, id })
 
-  const operations = await matches
+  const operations = await fun(matches)
     .pipe(createStream())
-    .pipe(fun())
     .map(key => ({
       type: 'del',
       key


### PR DESCRIPTION
By making `matches` fun, any errors that it emits will be propagated down the chain and result in a promise rejection. Without this, errors would result in a node `Unhandled error event` error.